### PR TITLE
Exposing dApps via sub-domains instead of path

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,6 +64,11 @@ npm install
 
 The default config assumes that the yagna app-key is available in your environment as `YAGNA_APPKEY`.
 
+### `proxy` settings
+
+- `exposeDomain` (**required**, example: _"dapp.golem.network"_) - the domain which will be used to expose HTTP interfaces of the deployed application
+- `exposeProtocol` (**required**, example: _"https"_) - the protocol which will be used to build the links to the exposed HTTP interfaces
+
 ## Start the app
 
 ```bash

--- a/backend/config/development.json
+++ b/backend/config/development.json
@@ -39,6 +39,7 @@
     "openPortTimeout": 3600,
     "checkPortInterval": 1000,
     "checkPortAttempts": 30,
-    "baseUrl": "http://localhost/app/"
+    "exposeDomain": "dapp.golem.network",
+    "exposeProtocol": "http"
   }
 }

--- a/backend/src/services/dapp/ProxyService.js
+++ b/backend/src/services/dapp/ProxyService.js
@@ -1,10 +1,17 @@
 const { Ok, UserError } = require("../../utils/Result");
+const assert = require("assert");
 
 module.exports = ({ redisClient, logger, config }) => {
-  const OPEN_PORT_TIMEOUT = config.proxy.openPortTimeout;
-  const CHECK_PORT_INTERVAL = config.proxy.checkPortInterval;
-  const CHECK_PORT_ATTEMPTS = config.proxy.checkPortAttempts;
-  const PROXY_PREFIX = config.proxy.baseUrl;
+  const {
+    openPortTimeout: OPEN_PORT_TIMEOUT,
+    checkPortInterval: CHECK_PORT_INTERVAL,
+    checkPortAttempts: CHECK_PORT_ATTEMPTS,
+    exposeDomain: PROXY_DOMAIN,
+    exposeProtocol: PROXY_PROTOCOL,
+  } = config.proxy;
+
+  assert(PROXY_PROTOCOL, "The proxy 'exposeProtocol' setting is required");
+  assert(PROXY_DOMAIN, "The proxy 'exposeDomain' setting is required");
 
   async function requestOpenPortForAppId(appId, port) {
     logger.debug(`[ProxyService] requestOpenPortForAppId: ${appId} ${port}`);
@@ -58,7 +65,7 @@ module.exports = ({ redisClient, logger, config }) => {
       return Ok({
         appId,
         port,
-        proxyUrl: PROXY_PREFIX + appId,
+        proxyUrl: `${PROXY_PROTOCOL}://${appId}.${PROXY_DOMAIN}/`,
       });
     },
   };

--- a/backend/src/services/dapp/ProxyService.test.js
+++ b/backend/src/services/dapp/ProxyService.test.js
@@ -6,7 +6,8 @@ const config = {
     openPortTimeout: 3600,
     checkPortInterval: 1000,
     checkPortAttempts: 30,
-    baseUrl: "http://test-domain.golem.network/app/",
+    exposeDomain: "dapp.golem.network",
+    exposeProtocol: "http",
   },
 };
 
@@ -43,6 +44,6 @@ describe("Proxy Service", () => {
     const result = await service.getProxyUrl(appId, 8080);
 
     // Then
-    expect(result.payload.proxyUrl).toEqual("http://test-domain.golem.network/app/testAppId");
+    expect(result.payload.proxyUrl).toEqual("http://testAppId.dapp.golem.network/");
   });
 });


### PR DESCRIPTION
- [Added] The `proxy.exposeDomain` and `proxy.exposeProtocol` do replace the removed `proxy.baseUrl` configuration value. The application will fail to start if these settings are not provided.
- [Removed] The `proxy.baseUrl` is no longer supported and has been removed.