### PR TITLE
Prevent killing backend on unauthenticated api call

### DIFF
--- a/backend/src/server/middlewares/Authentication.js
+++ b/backend/src/server/middlewares/Authentication.js
@@ -1,10 +1,13 @@
 module.exports = (server, config, logger, authentication) => {
-  server.pre(async (req, res) => {
+  server.pre((req, res, next) => {
     const { url } = req;
     if (url !== "/api/user/register/") {
       const token = req.header("Authorization");
       if (token) {
-        req.user = await authentication.authenticate(token);
+        authentication.authenticate(token).then((user) => {
+          req.user = user;
+          next();
+        });
       } else {
         res.send(401, "Missing Authorization header").end();
       }


### PR DESCRIPTION
there was async style middleware in use that causes interaction with already sent server response.Now its under control with callback style.

fixes #69