### PR TITLE
Implemented #78 - Exposing application image size stats

### DIFF
--- a/backend/src/adapters/CliAdapter.js
+++ b/backend/src/adapters/CliAdapter.js
@@ -59,5 +59,14 @@ module.exports = (dManagerCmd, dStatsCmd) => {
 
       return JSON.parse(result.stdout);
     },
+    async getSize(descriptorPath) {
+      const result = await dStatsCmd.run("size", descriptorPath);
+
+      if (result.status !== 0) {
+        throw new Error("The stats command failed to execute, no size information available");
+      }
+
+      return JSON.parse(result.stdout);
+    },
   };
 };

--- a/backend/src/adapters/CliAdapter.test.js
+++ b/backend/src/adapters/CliAdapter.test.js
@@ -98,4 +98,44 @@ describe("CLI Adapter", () => {
       );
     });
   });
+
+  describe("getSize - getting gvmi size information for particular app", () => {
+    test("returns JSON with the stats obtained by dapp-stats size based on the descriptor file", async () => {
+      const expectedResult = {
+        total_size: 82396693,
+        payloads: {
+          db: 24281724,
+          http: 58114969,
+        },
+      };
+
+      const adapter = CliAdapter(dManagerCmd, dStatsCmd);
+
+      when(dStatsCmd.run)
+        .calledWith("size", "some-descriptor.yaml")
+        .mockResolvedValue({
+          status: 0,
+          stdout: JSON.stringify(expectedResult),
+        });
+
+      const result = await adapter.getSize("some-descriptor.yaml");
+
+      // Then
+      expect(result).toEqual(expectedResult);
+    });
+
+    test("throws an error when the result code is non-zero", async () => {
+      const adapter = CliAdapter(dManagerCmd, dStatsCmd);
+      // When
+      when(dStatsCmd.run).calledWith("size", "some-descriptor.yaml").mockResolvedValue({
+        status: 2,
+        stdout: "",
+      });
+
+      // Then
+      await expect(adapter.getSize("some-descriptor.yaml")).rejects.toThrow(
+        "The stats command failed to execute, no size information available"
+      );
+    });
+  });
 });

--- a/backend/src/controllers/DappController.js
+++ b/backend/src/controllers/DappController.js
@@ -1,4 +1,4 @@
-module.exports = (dappService, storeService) => {
+module.exports = (dappService, storeService, statsService) => {
   return [
     {
       method: "get",
@@ -92,8 +92,8 @@ module.exports = (dappService, storeService) => {
       method: "get",
       path: "/dapp/:appId/stats",
       handler: async (req, res) => {
-        const data = await dappService.getStats(req.user.id, req.params.appId);
-        return res.send(200, data).end();
+        const stats = await statsService.getStatsForInstance(req.user.id, req.params.appId);
+        return res.send(200, stats).end();
       },
     },
     {

--- a/backend/src/di-config/AppConfig.js
+++ b/backend/src/di-config/AppConfig.js
@@ -8,18 +8,22 @@ const StoreService = require("../services/store/StoreService");
 const StoreController = require("../controllers/StoreController");
 const DappService = require("../services/dapp/DappService");
 const DappController = require("../controllers/DappController");
+const StatsService = require("../services/dapp/StatsService");
 
 module.exports = (logger, cliAdapter, dbDriver, redisClient, config) => {
+  // Database Layer
   const database = Database(dbDriver, logger);
 
+  // Domain Service Layer
   const userService = UserService({ database, logger });
-  const userController = UserController(userService);
-
   const storeService = StoreService({ database, logger });
-  const storeController = StoreController(storeService);
-
   const dappService = DappService({ database, logger, cliAdapter, redisClient, config });
-  const dappController = DappController(dappService, storeService);
+  const statsService = StatsService({ dappService, storeService });
+
+  // Controller layer
+  const storeController = StoreController(storeService);
+  const dappController = DappController(dappService, storeService, statsService);
+  const userController = UserController(userService);
 
   if (!process.env.YAGNA_APPKEY) {
     logger.error("Make sure that you set YAGNA_APPKEY environment variable, otherwise the requestor app won't work!");

--- a/backend/src/services/dapp/RunService.js
+++ b/backend/src/services/dapp/RunService.js
@@ -57,6 +57,14 @@ module.exports = ({ cliAdapter, database, logger }) => {
 
       return Ok(feedback);
     },
+    async getAppImageSizes(descriptorPath) {
+      const feedback = await cliAdapter.getSize(descriptorPath);
+      if (!feedback) {
+        throw new Error("No feedback from CliAdapter for app sizes - path %s", descriptorPath);
+      }
+
+      return Ok(feedback);
+    },
     async getInstanceInfo(userId, appId) {
       assertAppId(appId);
 

--- a/backend/src/services/dapp/StatsService.js
+++ b/backend/src/services/dapp/StatsService.js
@@ -1,0 +1,19 @@
+const { Ok } = require("../../utils/Result");
+
+module.exports = function StatsService({ dappService, storeService }) {
+  async function getStatsForInstance(userId, instanceId) {
+    const appInstance = await dappService.getInstanceInfo(userId, instanceId);
+    const appInformation = storeService.getAppById(appInstance.payload.appStoreId);
+    const size = await dappService.getAppImageSizes(appInformation.payload.descriptorPath);
+    const general = await dappService.getStats(userId, instanceId);
+
+    return Ok({
+      general: general.payload,
+      size: size.payload,
+    });
+  }
+
+  return {
+    getStatsForInstance,
+  };
+};

--- a/backend/src/services/store/StoreService.js
+++ b/backend/src/services/store/StoreService.js
@@ -5,6 +5,9 @@ module.exports = ({ database }) => {
     async getDapps() {
       return Ok(await database.findAllStoreDApps());
     },
+    getAppById(storeAppId) {
+      return Ok(database.findDAppById(storeAppId));
+    },
     getDescriptorForApp(storeAppId) {
       return Ok(database.loadDescriptorForApp(storeAppId));
     },

--- a/frontend/src/components/App/Stats/AppImageSizeCard.vue
+++ b/frontend/src/components/App/Stats/AppImageSizeCard.vue
@@ -1,0 +1,41 @@
+<template>
+  <q-card flat unelevated>
+    <q-card-section>
+      <div class="text-h6">
+        <q-icon name="scale" color="primary" />
+        Image size information
+      </div>
+    </q-card-section>
+    <q-markup-table>
+      <tbody>
+        <tr>
+          <td>Total size of application images</td>
+          <td>{{ bytesToMb(stats.total_size) }} MB</td>
+        </tr>
+        <tr v-for="[name, size] of Object.entries(stats.payloads)" :key="name">
+          <td>Payload: {{ name }}</td>
+          <td>{{ bytesToMb(size) }} MB</td>
+        </tr>
+      </tbody>
+    </q-markup-table>
+  </q-card>
+</template>
+
+<script>
+export default {
+  name: "AppImageSizeCard",
+  props: {
+    stats: {
+      type: Object,
+      required: true,
+    },
+  },
+  setup() {
+    return {
+      bytesToMb(bytes) {
+        return (bytes / 1024 / 1024).toFixed(2);
+      },
+    };
+  },
+};
+</script>

--- a/frontend/src/components/App/Stats/AppStatCard.vue
+++ b/frontend/src/components/App/Stats/AppStatCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card class="my" flat unelevated>
+  <q-card flat unelevated>
     <q-card-section>
       <div class="text-h6">
         <slot />

--- a/frontend/src/components/App/Stats/AppStatList.vue
+++ b/frontend/src/components/App/Stats/AppStatList.vue
@@ -25,10 +25,10 @@ export default defineComponent({
     v-for="[instanceKey, stats] in Object.entries(instances)"
     :key="instanceKey"
     :stats="stats"
-    class="q-my-lg"
     flat
     unelevated
   >
-    Stats for "{{ type }}-{{ instanceKey }}"
+    <q-icon name="account_tree" color="secondary" />
+    Stats for "{{ type }}"
   </AppStatCard>
 </template>

--- a/frontend/src/components/App/Stats/AppStats.vue
+++ b/frontend/src/components/App/Stats/AppStats.vue
@@ -5,10 +5,11 @@ import AppStatCard from "components/App/Stats/AppStatCard.vue";
 import { api } from "boot/axios";
 import { useQuasar } from "quasar";
 import AlertNegative from "components/Alert/AlertNegative.vue";
+import AppImageSizeCard from "components/App/Stats/AppImageSizeCard.vue";
 
 export default defineComponent({
   name: "AppStats",
-  components: { AlertNegative, AppStatCard, AppStatList },
+  components: { AlertNegative, AppStatCard, AppStatList, AppImageSizeCard },
   props: {
     app: {
       type: Object,
@@ -43,17 +44,22 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="col">
-    <AppStatCard v-if="stats" :stats="stats.app">
-      Summarised application stats
-    </AppStatCard>
-    <div v-if="stats">
-      <AppStatList
-        v-for="[nodeType, nodeInstances] in Object.entries(stats.nodes)"
-        :key="nodeType"
-        :instances="nodeInstances"
-        :type="nodeType"
-      />
+  <div class="row justify-between">
+    <div class="col-xs-12 col-lg-6 q-pa-sm">
+      <AppStatCard v-if="stats.general" :stats="stats.general.app">
+        <q-icon name="summarize" color="primary" />
+        Summarised application stats
+      </AppStatCard>
+    </div>
+    <div class="col-xs-12 col-lg-6 q-pa-sm">
+      <AppImageSizeCard v-if="stats.size" class="col-6" :stats="stats.size" />
+    </div>
+    <div
+      v-for="[nodeType, nodeInstances] in Object.entries(stats.general.nodes)"
+      :key="nodeType"
+      class="col-xs-12 col-lg-6 q-pa-sm"
+    >
+      <AppStatList :instances="nodeInstances" :type="nodeType" />
     </div>
     <AlertNegative v-if="error">Failed to load the app stats :(</AlertNegative>
   </div>

--- a/frontend/src/pages/DetailsPage.vue
+++ b/frontend/src/pages/DetailsPage.vue
@@ -5,8 +5,8 @@
         <PageTitle :value="dapp.name" />
       </div>
       <div class="row">
-        <div class="col-md-4 col-sm-6 col-xs-12">
-          <q-card flat class="q-ma-sm">
+        <div class="col-md-4 col-sm-6 col-xs-12 q-pa-sm">
+          <q-card flat>
             <q-card-section>
               <AppProperty name="Status">
                 <AppStatusBadge :status="dapp.status" />
@@ -17,9 +17,9 @@
         </div>
         <div
           v-if="isOperational() && descriptor && usesHttpProxy()"
-          class="col-md-4 col-sm-6 col-xs-12"
+          class="col-md-4 col-sm-6 col-xs-12 q-pa-sm"
         >
-          <q-card flat class="q-ma-sm">
+          <q-card flat>
             <q-card-section>
               <AppProperty name="Local access link">
                 <AppLink
@@ -39,8 +39,8 @@
             </q-card-section>
           </q-card>
         </div>
-        <div v-if="dapp.status === 'active'" class="col-md-4 col-xs-12">
-          <q-card flat class="q-ma-sm">
+        <div v-if="dapp.status === 'active'" class="col-md-4 col-xs-12 q-pa-sm">
+          <q-card flat>
             <q-card-section>
               <q-btn
                 v-if="dapp.status === 'active'"


### PR DESCRIPTION
This PR exposes application image stats delivered by the most recent version of `dapp-stats`.

## Important note

* This code requires dapp-manager which supports dapp-stats. You need to install dapp-manager from their repo, and not just from global pip repository.

This can be done via, checking-out dapp-manager repo locally and installing it from sources:

```bash
# Inside the dapp-manage repo
git checkout main
git pull
pip uninstall dapp-manager
pip uninstall dapp-runner
pip install --force-reinstall .
```