### PR TITLE
Add worker that updates status of dapps

### DIFF
--- a/backend/config/development.json
+++ b/backend/config/development.json
@@ -33,5 +33,9 @@
     "checkPortAttempts": 30,
     "exposeDomain": "dapp.golem.network",
     "exposeProtocol": "http"
+  },
+  "limits": {
+    "maxCountUserDapps": 3,
+    "maxCountGlobalDapps": 200
   }
 }

--- a/backend/config/development.json
+++ b/backend/config/development.json
@@ -37,5 +37,9 @@
   "limits": {
     "maxCountUserDapps": 3,
     "maxCountGlobalDapps": 200
+  },
+  "worker": {
+    "cronSchedule": "*/10 * * * * *"
   }
 }
+

--- a/backend/migrations/20230111113823-add-status.js
+++ b/backend/migrations/20230111113823-add-status.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230111113823-add-status-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230111113823-add-status-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/backend/migrations/20230111113823-add-status.js
+++ b/backend/migrations/20230111113823-add-status.js
@@ -1,53 +1,51 @@
-'use strict';
+"use strict";
 
 var dbm;
 var type;
 var seed;
-var fs = require('fs');
-var path = require('path');
+var fs = require("fs");
+var path = require("path");
 var Promise;
 
 /**
-  * We receive the dbmigrate dependency from dbmigrate initially.
-  * This enables us to not have to rely on NODE_PATH.
-  */
-exports.setup = function(options, seedLink) {
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
   Promise = options.Promise;
 };
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20230111113823-add-status-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+exports.up = function (db) {
+  var filePath = path.join(__dirname, "sqls", "20230111113823-add-status-up.sql");
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
       if (err) return reject(err);
-      console.log('received data: ' + data);
+      console.log("received data: " + data);
 
       resolve(data);
     });
-  })
-  .then(function(data) {
+  }).then(function (data) {
     return db.runSql(data);
   });
 };
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20230111113823-add-status-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+exports.down = function (db) {
+  var filePath = path.join(__dirname, "sqls", "20230111113823-add-status-down.sql");
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: "utf-8" }, function (err, data) {
       if (err) return reject(err);
-      console.log('received data: ' + data);
+      console.log("received data: " + data);
 
       resolve(data);
     });
-  })
-  .then(function(data) {
+  }).then(function (data) {
     return db.runSql(data);
   });
 };
 
 exports._meta = {
-  "version": 1
+  version: 1,
 };

--- a/backend/migrations/sqls/20230111113823-add-status-down.sql
+++ b/backend/migrations/sqls/20230111113823-add-status-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/backend/migrations/sqls/20230111113823-add-status-up.sql
+++ b/backend/migrations/sqls/20230111113823-add-status-up.sql
@@ -1,0 +1,3 @@
+/* Replace with your SQL commands */
+ALTER TABLE dapp
+ADD status varchar(20);

--- a/backend/src/adapters/Config.js
+++ b/backend/src/adapters/Config.js
@@ -8,4 +8,5 @@ module.exports = {
   redis: config.get("redis"),
   sqlite: config.get("sqlite"),
   proxy: config.get("proxy"),
+  limits: config.get("limits"),
 };

--- a/backend/src/adapters/Config.js
+++ b/backend/src/adapters/Config.js
@@ -9,4 +9,5 @@ module.exports = {
   sqlite: config.get("sqlite"),
   proxy: config.get("proxy"),
   limits: config.get("limits"),
+  worker: config.get("worker"),
 };

--- a/backend/src/controllers/DappController.js
+++ b/backend/src/controllers/DappController.js
@@ -24,7 +24,7 @@ module.exports = (dappService, storeService, quoteService) => {
         if (!userAndGlobalCount) {
           return res.send(429, userAndGlobalCount).end();
         }
-        
+
         const dapps = await dappService.start(req.user.id, req.body.appStoreId);
         return res.send(201, dapps).end();
       },

--- a/backend/src/controllers/DappController.js
+++ b/backend/src/controllers/DappController.js
@@ -1,4 +1,4 @@
-module.exports = (dappService, storeService) => {
+module.exports = (dappService, storeService, quoteService) => {
   return [
     {
       method: "get",
@@ -20,6 +20,11 @@ module.exports = (dappService, storeService) => {
       method: "post",
       path: "/dapp/start/",
       handler: async (req, res) => {
+        const userAndGlobalCount = await quoteService.userAndGlobalCount(req.user.id);
+        if (!userAndGlobalCount) {
+          return res.send(429, userAndGlobalCount).end();
+        }
+        
         const dapps = await dappService.start(req.user.id, req.body.appStoreId);
         return res.send(201, dapps).end();
       },

--- a/backend/src/db/DappDatabase.js
+++ b/backend/src/db/DappDatabase.js
@@ -19,13 +19,14 @@ module.exports = function DappDatabase(db) {
         });
       });
     },
-    insertDapp(userId, appId, appStoreId) {
+    insertDapp(userId, appId, appStoreId, dappStatus) {
       return new Promise((res, rej) => {
         db.run(
-          "INSERT OR REPLACE INTO dapp (userId, appId, appStoreId, createdAt) values (?, ?, ?, ?)",
+          "INSERT OR REPLACE INTO dapp (userId, appId, appStoreId, status, createdAt) values (?, ?, ?, ?, ?)",
           userId,
           appId,
           appStoreId,
+          dappStatus,
           new Date().toISOString(),
           (err) => {
             if (err) rej(err);

--- a/backend/src/db/DappDatabase.js
+++ b/backend/src/db/DappDatabase.js
@@ -35,12 +35,21 @@ module.exports = function DappDatabase(db) {
         );
       });
     },
-    updateDappStatus(userId, appId, dappStatus) {
+    updateDappStatus(userId=false, appId, dappStatus) {
       return new Promise((res, rej) => {
+        if (userId) {
+          // Used for the dapp start method, where the userId is known.
         db.run("UPDATE dapp SET status=? WHERE userId=? AND appId=?", dappStatus, userId, appId, (err) => {
           if (err) rej(err);
           else res();
         });
+        } else {
+          // Cron worker is not aware of userId's , so it simply just updates the status of a specific appId.
+          db.run("UPDATE dapp SET status=? WHERE appId=?", dappStatus, appId, (err) => {
+            if (err) rej(err);
+            else res();
+          });
+        } 
       });
     },
     deleteDApp(userId, appId) {

--- a/backend/src/db/DappDatabase.js
+++ b/backend/src/db/DappDatabase.js
@@ -35,6 +35,14 @@ module.exports = function DappDatabase(db) {
         );
       });
     },
+    updateDappStatus(userId, appId, dappStatus) {
+      return new Promise((res, rej) => {
+        db.run("UPDATE dapp SET status=? WHERE userId=? AND appId=?", dappStatus, userId, appId, (err) => {
+          if (err) rej(err);
+          else res();
+        });
+      });
+    },
     deleteDApp(userId, appId) {
       return new Promise((res, rej) => {
         db.run("DELETE FROM dapp WHERE userId=? AND appId=?", userId, appId, (err) => {

--- a/backend/src/db/Database.js
+++ b/backend/src/db/Database.js
@@ -1,12 +1,14 @@
 const UserDatabase = require("./UserDatabase");
 const StoreDatabase = require("./StoreDatabase");
 const DappDatabase = require("./DappDatabase");
+const QuotesDatabase = require("./QuotesDatabase");
 
 const Database = (dbDriver, logger) => {
   return {
     ...UserDatabase(dbDriver),
     ...StoreDatabase(dbDriver, logger),
     ...DappDatabase(dbDriver),
+    ...QuotesDatabase(dbDriver),
   };
 };
 

--- a/backend/src/db/QuotesDatabase.js
+++ b/backend/src/db/QuotesDatabase.js
@@ -1,0 +1,20 @@
+module.exports = function DappDatabase(db) {
+  return {
+    countUsersRunningDapps(userId) {
+      return new Promise((res, rej) => {
+        db.get("SELECT COUNT(*) AS count FROM dapp WHERE userId=? AND status='running'", userId, (err, row) => {
+          if (err) rej(err);
+          else res(row);
+        });
+      });
+    },
+    countGlobalRunningDapps() {
+      return new Promise((res, rej) => {
+        db.get("SELECT COUNT(*) AS count FROM dapp WHERE status='running'", (err, row) => {
+          if (err) rej(err);
+          else res(row);
+        });
+      });
+    },
+  };
+};

--- a/backend/src/di-config/AppConfig.js
+++ b/backend/src/di-config/AppConfig.js
@@ -8,9 +8,12 @@ const StoreService = require("../services/store/StoreService");
 const StoreController = require("../controllers/StoreController");
 const DappService = require("../services/dapp/DappService");
 const DappController = require("../controllers/DappController");
+const ServiceQuotes = require("../services/dapp/ServiceQuotes");
 
 module.exports = (logger, cliAdapter, dbDriver, redisClient, config) => {
   const database = Database(dbDriver, logger);
+
+  const quoteService = ServiceQuotes({ database, logger })
 
   const userService = UserService({ database, logger });
   const userController = UserController(userService);
@@ -19,7 +22,7 @@ module.exports = (logger, cliAdapter, dbDriver, redisClient, config) => {
   const storeController = StoreController(storeService);
 
   const dappService = DappService({ database, logger, cliAdapter, redisClient, config });
-  const dappController = DappController(dappService, storeService);
+  const dappController = DappController(dappService, storeService, quoteService);
 
   if (!process.env.YAGNA_APPKEY) {
     logger.error("Make sure that you set YAGNA_APPKEY environment variable, otherwise the requestor app won't work!");

--- a/backend/src/di-config/AppConfig.js
+++ b/backend/src/di-config/AppConfig.js
@@ -13,7 +13,7 @@ const ServiceQuotes = require("../services/dapp/ServiceQuotes");
 module.exports = (logger, cliAdapter, dbDriver, redisClient, config) => {
   const database = Database(dbDriver, logger);
 
-  const quoteService = ServiceQuotes({ database, logger, config })
+  const quoteService = ServiceQuotes({ database, logger, config });
 
   const userService = UserService({ database, logger });
   const userController = UserController(userService);

--- a/backend/src/di-config/AppConfig.js
+++ b/backend/src/di-config/AppConfig.js
@@ -13,7 +13,7 @@ const ServiceQuotes = require("../services/dapp/ServiceQuotes");
 module.exports = (logger, cliAdapter, dbDriver, redisClient, config) => {
   const database = Database(dbDriver, logger);
 
-  const quoteService = ServiceQuotes({ database, logger })
+  const quoteService = ServiceQuotes({ database, logger, config })
 
   const userService = UserService({ database, logger });
   const userController = UserController(userService);

--- a/backend/src/services/dapp/DappService.js
+++ b/backend/src/services/dapp/DappService.js
@@ -8,6 +8,6 @@ module.exports = ({ database, logger, cliAdapter, redisClient, config }) => {
     ...GetDappsService({ database, cliAdapter }),
     ...RunService({ database, logger, cliAdapter }),
     ...ProxyService({ redisClient, logger, config }),
-    ...ServiceQuotes({ database, logger }),
+    ...ServiceQuotes({ database, logger, config }),
   };
 };

--- a/backend/src/services/dapp/DappService.js
+++ b/backend/src/services/dapp/DappService.js
@@ -1,11 +1,13 @@
 const GetDappsService = require("./GetDappsService");
 const ProxyService = require("./ProxyService");
 const RunService = require("./RunService");
+const ServiceQuotes = require("./ServiceQuotes");
 
 module.exports = ({ database, logger, cliAdapter, redisClient, config }) => {
   return {
     ...GetDappsService({ database, cliAdapter }),
     ...RunService({ database, logger, cliAdapter }),
     ...ProxyService({ redisClient, logger, config }),
+    ...ServiceQuotes({ database, logger }),
   };
 };

--- a/backend/src/services/dapp/RunService.js
+++ b/backend/src/services/dapp/RunService.js
@@ -18,7 +18,8 @@ module.exports = ({ cliAdapter, database, logger }) => {
       }
 
       const [appId] = await cliAdapter.start(resolve(dappStore.configPath), resolve(dappStore.descriptorPath));
-      await database.insertDapp(userId, appId, appStoreId);
+      const status = "running"
+      await database.insertDapp(userId, appId, appStoreId, status);
       logger.info(`App ${appId} has been launched by user ${userId}`);
 
       return Ok(appId);

--- a/backend/src/services/dapp/RunService.js
+++ b/backend/src/services/dapp/RunService.js
@@ -18,7 +18,7 @@ module.exports = ({ cliAdapter, database, logger }) => {
       }
 
       const [appId] = await cliAdapter.start(resolve(dappStore.configPath), resolve(dappStore.descriptorPath));
-      const status = "running"
+      const status = "running";
       await database.insertDapp(userId, appId, appStoreId, status);
       logger.info(`App ${appId} has been launched by user ${userId}`);
 
@@ -28,7 +28,7 @@ module.exports = ({ cliAdapter, database, logger }) => {
       assertAppId(appId);
 
       const [stoppedAppId] = await cliAdapter.stop(appId);
-      const status = "stopped"
+      const status = "stopped";
       await database.updateDappStatus(userId, appId, status);
       logger.info(`App ${appId} has been stopped by user ${userId}`);
 
@@ -38,7 +38,7 @@ module.exports = ({ cliAdapter, database, logger }) => {
       assertAppId(appId);
 
       const [killedAppId] = await cliAdapter.kill(appId);
-      const status = "killed"
+      const status = "killed";
       await database.updateDappStatus(userId, appId, status);
       logger.info(`App ${appId} has been killed by user ${userId}`);
 

--- a/backend/src/services/dapp/RunService.js
+++ b/backend/src/services/dapp/RunService.js
@@ -28,6 +28,8 @@ module.exports = ({ cliAdapter, database, logger }) => {
       assertAppId(appId);
 
       const [stoppedAppId] = await cliAdapter.stop(appId);
+      const status = "stopped"
+      await database.updateDappStatus(userId, appId, status);
       logger.info(`App ${appId} has been stopped by user ${userId}`);
 
       return Ok(stoppedAppId);
@@ -36,6 +38,8 @@ module.exports = ({ cliAdapter, database, logger }) => {
       assertAppId(appId);
 
       const [killedAppId] = await cliAdapter.kill(appId);
+      const status = "killed"
+      await database.updateDappStatus(userId, appId, status);
       logger.info(`App ${appId} has been killed by user ${userId}`);
 
       return Ok(killedAppId);

--- a/backend/src/services/dapp/ServiceQuotes.js
+++ b/backend/src/services/dapp/ServiceQuotes.js
@@ -1,7 +1,18 @@
 const { UserError, Ok } = require("../../utils/Result");
 const { resolve } = require("path");
+const assert = require("assert");
 
-module.exports = ({ database, logger }) => {
+
+module.exports = ({ database, logger, config }) => {
+
+  const {
+    maxCountUserDapps: USER_DAPP_LIMIT,
+    maxCountGlobalDapps: GLOBAL_DAPP_LIMIT,
+  } = config.limits;
+
+  assert(USER_DAPP_LIMIT, "The limit 'maxCountUserDapps' setting is required");
+  assert(GLOBAL_DAPP_LIMIT, "The limit 'maxCountGlobalDapps' setting is required");
+
   function assertUserId(userId) {
     if (!userId) {
       throw new UserError("The id of a user is required");
@@ -18,7 +29,7 @@ module.exports = ({ database, logger }) => {
         throw new UserError(`User with id ${userId} could not be found`);
       }
 
-      if (dappCount < 3) {
+      if (dappCount < USER_DAPP_LIMIT) {
         logger.info(`Quote checker found ${dappCount} running services for user with id ${userId}`);
         return Ok(queryCount);
       } else {
@@ -40,11 +51,11 @@ module.exports = ({ database, logger }) => {
         throw new UserError(`An error occured during counting the global amount of running dapps`);
       }
 
-      if (globalDappCount >= 200) {
+      if (globalDappCount >= GLOBAL_DAPP_LIMIT) {
         throw new UserError(`The global limit of running dapps has been reached. Please try again later.`);
       }
 
-      if (userDappCount >= 3) {
+      if (userDappCount >= USER_DAPP_LIMIT) {
         throw new UserError(`You have reached the maximum amount of running services`);
       }
     

--- a/backend/src/services/dapp/ServiceQuotes.js
+++ b/backend/src/services/dapp/ServiceQuotes.js
@@ -6,9 +6,11 @@ const { spawn } = require("child_process");
 
 module.exports = ({ database, logger, config }) => {
   const { maxCountUserDapps: USER_DAPP_LIMIT, maxCountGlobalDapps: GLOBAL_DAPP_LIMIT } = config.limits;
+  const { cronSchedule: CRON_SCHEDULE } = config.worker;
 
   assert(USER_DAPP_LIMIT, "The limit 'maxCountUserDapps' setting is required");
   assert(GLOBAL_DAPP_LIMIT, "The limit 'maxCountGlobalDapps' setting is required");
+  assert(CRON_SCHEDULE, "The cron schedule for the 'cronSchedule' setting is required");
 
   function assertUserId(userId) {
     if (!userId) {
@@ -21,7 +23,7 @@ module.exports = ({ database, logger, config }) => {
 // with a stdio configuration that is not connected to the parent. 
 // If the parent's stdio is inherited, the child will remain attached to the controlling terminal.
 
-  cron.schedule('* * * * *', () => {
+  cron.schedule(CRON_SCHEDULE, () => {
     const dappManager = spawn('dapp-manager', ['list'], {
       detached: true,
     });

--- a/backend/src/services/dapp/ServiceQuotes.js
+++ b/backend/src/services/dapp/ServiceQuotes.js
@@ -2,13 +2,8 @@ const { UserError, Ok } = require("../../utils/Result");
 const { resolve } = require("path");
 const assert = require("assert");
 
-
 module.exports = ({ database, logger, config }) => {
-
-  const {
-    maxCountUserDapps: USER_DAPP_LIMIT,
-    maxCountGlobalDapps: GLOBAL_DAPP_LIMIT,
-  } = config.limits;
+  const { maxCountUserDapps: USER_DAPP_LIMIT, maxCountGlobalDapps: GLOBAL_DAPP_LIMIT } = config.limits;
 
   assert(USER_DAPP_LIMIT, "The limit 'maxCountUserDapps' setting is required");
   assert(GLOBAL_DAPP_LIMIT, "The limit 'maxCountGlobalDapps' setting is required");
@@ -24,7 +19,7 @@ module.exports = ({ database, logger, config }) => {
       assertUserId(userId);
 
       const queryCount = await database.countUsersRunningDapps(userId);
-      const dappCount = queryCount['count']
+      const dappCount = queryCount["count"];
       if (!queryCount) {
         throw new UserError(`User with id ${userId} could not be found`);
       }
@@ -40,13 +35,13 @@ module.exports = ({ database, logger, config }) => {
       assertUserId(userId);
 
       const queryUserCount = await database.countUsersRunningDapps(userId);
-      const userDappCount = queryUserCount['count']
+      const userDappCount = queryUserCount["count"];
       if (!queryUserCount) {
         throw new UserError(`We could not find a user with id ${userId} in our database`);
       }
 
       const queryGlobalCount = await database.countGlobalRunningDapps();
-      const globalDappCount = queryGlobalCount['count']
+      const globalDappCount = queryGlobalCount["count"];
       if (!queryGlobalCount) {
         throw new UserError(`An error occured during counting the global amount of running dapps`);
       }
@@ -58,13 +53,15 @@ module.exports = ({ database, logger, config }) => {
       if (userDappCount >= USER_DAPP_LIMIT) {
         throw new UserError(`You have reached the maximum amount of running services`);
       }
-    
-      logger.info(`Quote checker found ${userDappCount} running services for user with id ${userId} and a global count of ${globalDappCount} running dapps}`);
-      return Ok({'global': globalDappCount, 'user': userDappCount});
+
+      logger.info(
+        `Quote checker found ${userDappCount} running services for user with id ${userId} and a global count of ${globalDappCount} running dapps}`
+      );
+      return Ok({ global: globalDappCount, user: userDappCount });
     },
     async globalRunningDappCount() {
       const queryGlobalCount = await database.countGlobalRunningDapps();
-      const dappCount = queryGlobalCount['count']
+      const dappCount = queryGlobalCount["count"];
 
       if (!queryGlobalCount) {
         throw new UserError(`Error counting global amount of running dapps`);

--- a/backend/src/services/dapp/ServiceQuotes.js
+++ b/backend/src/services/dapp/ServiceQuotes.js
@@ -1,0 +1,66 @@
+const { UserError, Ok } = require("../../utils/Result");
+const { resolve } = require("path");
+
+module.exports = ({ database, logger }) => {
+  function assertUserId(userId) {
+    if (!userId) {
+      throw new UserError("The id of a user is required");
+    }
+  }
+
+  return {
+    async userRunningDappCount(userId) {
+      assertUserId(userId);
+
+      const queryCount = await database.countUsersRunningDapps(userId);
+      const dappCount = queryCount['count']
+      if (!queryCount) {
+        throw new UserError(`User with id ${userId} could not be found`);
+      }
+
+      if (dappCount < 3) {
+        logger.info(`Quote checker found ${dappCount} running services for user with id ${userId}`);
+        return Ok(queryCount);
+      } else {
+        throw new UserError(`User with id ${userId} has reached the maximum amount of running services`);
+      }
+    },
+    async userAndGlobalCount(userId) {
+      assertUserId(userId);
+
+      const queryUserCount = await database.countUsersRunningDapps(userId);
+      const userDappCount = queryUserCount['count']
+      if (!queryUserCount) {
+        throw new UserError(`We could not find a user with id ${userId} in our database`);
+      }
+
+      const queryGlobalCount = await database.countGlobalRunningDapps();
+      const globalDappCount = queryGlobalCount['count']
+      if (!queryGlobalCount) {
+        throw new UserError(`An error occured during counting the global amount of running dapps`);
+      }
+
+      if (globalDappCount >= 200) {
+        throw new UserError(`The global limit of running dapps has been reached. Please try again later.`);
+      }
+
+      if (userDappCount >= 3) {
+        throw new UserError(`You have reached the maximum amount of running services`);
+      }
+    
+      logger.info(`Quote checker found ${userDappCount} running services for user with id ${userId} and a global count of ${globalDappCount} running dapps}`);
+      return Ok({'global': globalDappCount, 'user': userDappCount});
+    },
+    async globalRunningDappCount() {
+      const queryGlobalCount = await database.countGlobalRunningDapps();
+      const dappCount = queryGlobalCount['count']
+
+      if (!queryGlobalCount) {
+        throw new UserError(`Error counting global amount of running dapps`);
+      }
+      logger.info(`Quote checker found ${dappCount} running services globally`);
+
+      return Ok(queryGlobalCount);
+    },
+  };
+};


### PR DESCRIPTION
Solves #76 

### Implemented
- Cron worker queries all known dapps from the dapp-manager and updates the database with their current status.
- Added an extra key inside `development.json` that will allow one to configure the cron schedule that the worker uses. Default is every 10 seconds.

### Missing
- Given I'm on the app catalogue and the global quota is exhausted, then the "Run" button on the tile is "Disabled" with a note that the user has to wait for new free slots.
-  Implement API endpoint which will tell me if slots are available, read the number of running apps from DB
