### PR TITLE
fix: First interaction leads to errors and breaks the app

### DIFF
--- a/backend/src/server/middlewares/Authentication.js
+++ b/backend/src/server/middlewares/Authentication.js
@@ -11,6 +11,7 @@ module.exports = (server, config, logger, authentication) => {
       } else {
         res.send(401, "Missing Authorization header").end();
       }
+      // If the user is registering, we don't need to authenticate them.
     } else {
       next();
     }

--- a/backend/src/server/middlewares/Authentication.js
+++ b/backend/src/server/middlewares/Authentication.js
@@ -11,6 +11,8 @@ module.exports = (server, config, logger, authentication) => {
       } else {
         res.send(401, "Missing Authorization header").end();
       }
+    } else {
+      next();
     }
   });
 };

--- a/frontend/src/boot/axios.js
+++ b/frontend/src/boot/axios.js
@@ -7,7 +7,7 @@ const api = axios.create({ baseURL: process.env.API_BACKEND_URL });
 export default boot(({ app, store }) => {
   const userStore = useUserStore(store);
 
-  const getOrCreateUserId = async () => {
+  const obtainUserId = async () => {
     if (!userStore.user) {
       await userStore.register();
     }
@@ -16,7 +16,7 @@ export default boot(({ app, store }) => {
 
   api.interceptors.request.use(
     async (config) => {
-      const userId = await getOrCreateUserId();
+      const userId = await obtainUserId();
       config.headers["Authorization"] = userId;
       return config;
     },

--- a/frontend/src/boot/axios.js
+++ b/frontend/src/boot/axios.js
@@ -2,17 +2,22 @@ import { boot } from "quasar/wrappers";
 import axios from "axios";
 import { Notify } from "quasar";
 import { useUserStore } from "stores/user";
-
 const api = axios.create({ baseURL: process.env.API_BACKEND_URL });
 
 export default boot(({ app, store }) => {
   const userStore = useUserStore(store);
 
+  const getOrCreateUserId = async () => {
+    if (!userStore.user) {
+      await userStore.register();
+    }
+    return userStore.user.id;
+  };
+
   api.interceptors.request.use(
-    (config) => {
-      if (userStore.user) {
-        config.headers["Authorization"] = userStore.user.id;
-      }
+    async (config) => {
+      const userId = await getOrCreateUserId();
+      config.headers["Authorization"] = userId;
       return config;
     },
     (error) => {

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -90,18 +90,12 @@
 
 <script>
 import { ref } from "vue";
-import { useUserStore } from "stores/user";
 import DiscordInvite from "components/Navigation/DiscordInvite.vue";
 export default {
   components: { DiscordInvite },
   setup() {
     const miniState = ref(false);
     const leftDrawerOpen = ref(false);
-    const userStore = useUserStore();
-
-    if (!userStore.user) {
-      userStore.register();
-    }
 
     return {
       miniState,


### PR DESCRIPTION
Now checks on each request if the user.id exists else it creates it and then sends the request.

Had to fix the backend middleware as it was not responding to my registration requests, and that was because the middleware did not run next(); if the URL matched the registration endpoint.

Also removed the code block that checks if the user is registered from the MainLayout. It's not necessary anymore.